### PR TITLE
fix: Updating the documentation and the constructor file to reflect Amazon Managed Blockchain support for the Goerli testnet

### DIFF
--- a/API.md
+++ b/API.md
@@ -299,8 +299,9 @@ Supported Ethereum networks for Managed Blockchain nodes.
 | **Name** | **Description** |
 | --- | --- |
 | <code><a href="#@cdklabs/cdk-ethereum-node.Network.MAINNET">MAINNET</a></code> | *No description.* |
-| <code><a href="#@cdklabs/cdk-ethereum-node.Network.ROPSTEN">ROPSTEN</a></code> | *No description.* |
+| <code><a href="#@cdklabs/cdk-ethereum-node.Network.GOERLI">GOERLI</a></code> | *No description.* |
 | <code><a href="#@cdklabs/cdk-ethereum-node.Network.RINKEBY">RINKEBY</a></code> | *No description.* |
+| <code><a href="#@cdklabs/cdk-ethereum-node.Network.ROPSTEN">ROPSTEN</a></code> | *No description.* |
 
 ---
 
@@ -309,12 +310,17 @@ Supported Ethereum networks for Managed Blockchain nodes.
 ---
 
 
-##### `ROPSTEN` <a name="ROPSTEN" id="@cdklabs/cdk-ethereum-node.Network.ROPSTEN"></a>
+##### `GOERLI` <a name="GOERLI" id="@cdklabs/cdk-ethereum-node.Network.GOERLI"></a>
 
 ---
 
 
 ##### `RINKEBY` <a name="RINKEBY" id="@cdklabs/cdk-ethereum-node.Network.RINKEBY"></a>
+
+---
+
+
+##### `ROPSTEN` <a name="ROPSTEN" id="@cdklabs/cdk-ethereum-node.Network.ROPSTEN"></a>
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@ This repository contains a CDK construct to deploy an Ethereum node running
 on Amazon Managed Blockchain. The following networks are supported:
 
 *  Mainnet (default)
-*  Testnet: Ropsten
+*  Testnet: Goerli
 *  Testnet: Rinkeby
+*  Testnet: Ropsten
 
-<!-- TODO: add a documentation note here about Goerli network -->
 
 
 ## Installation

--- a/src/node.ts
+++ b/src/node.ts
@@ -30,8 +30,9 @@ export enum InstanceType {
  */
 export enum Network {
   MAINNET = 'n-ethereum-mainnet',
+  GOERLI = 'n-ethereum-goerli',
+  RINKEBY = 'n-ethereum-rinkeby',
   ROPSTEN = 'n-ethereum-ropsten',
-  RINKEBY = 'n-ethereum-rinkeby'
 }
 
 /**


### PR DESCRIPTION
The CDK v2 documentation for the Amazon Managed Blockchain CloudFormation resource [`CfnNode`](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_managedblockchain.CfnNode.html) did not previously include the Goerli testnet in its list of supported Ethereum networks. This error is now being corrected in the official AWS CDK v2 documentation, and therefore, I updated both the repo's README and this construct to include the Goerli network in the enum list of `Network` for node creation. 