### PR TITLE
Remove small instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,14 +93,6 @@ new EthereumNode(this, 'Example', {
 });
 ```
 
-The following provides an example of how to leverage the construct to deploy more than one node at a time.
-
-```typescript
-for (const i = 0; i < 10; i++) {
-  new EthereumNode(this, `Example_${i}`);
-}
-```
-
 See the [API Documentation](API.md) for details on all available input and output parameters.
 
 

--- a/src/node.ts
+++ b/src/node.ts
@@ -11,7 +11,6 @@ import * as utilities from './utilities';
  * Supported instance types for Managed Blockchain nodes
  */
 export enum InstanceType {
-  BURSTABLE3_SMALL = 'bc.t3.small',
   BURSTABLE3_MEDIUM = 'bc.t3.medium',
   BURSTABLE3_LARGE = 'bc.t3.large',
   BURSTABLE3_XLARGE = 'bc.t3.xlarge',


### PR DESCRIPTION
Removes t3.small instance from list as it's not available in AMB
Removes code to create multiple instances from README