### PR TITLE
fix: Updating the list of instance types available for Ethereum on Amazon Managed Blockchain

### DIFF
--- a/API.md
+++ b/API.md
@@ -228,24 +228,17 @@ Supported instance types for Managed Blockchain nodes.
 
 | **Name** | **Description** |
 | --- | --- |
-| <code><a href="#@cdklabs/cdk-ethereum-node.InstanceType.BURSTABLE3_MEDIUM">BURSTABLE3_MEDIUM</a></code> | *No description.* |
 | <code><a href="#@cdklabs/cdk-ethereum-node.InstanceType.BURSTABLE3_LARGE">BURSTABLE3_LARGE</a></code> | *No description.* |
 | <code><a href="#@cdklabs/cdk-ethereum-node.InstanceType.BURSTABLE3_XLARGE">BURSTABLE3_XLARGE</a></code> | *No description.* |
 | <code><a href="#@cdklabs/cdk-ethereum-node.InstanceType.STANDARD5_LARGE">STANDARD5_LARGE</a></code> | *No description.* |
 | <code><a href="#@cdklabs/cdk-ethereum-node.InstanceType.STANDARD5_XLARGE">STANDARD5_XLARGE</a></code> | *No description.* |
 | <code><a href="#@cdklabs/cdk-ethereum-node.InstanceType.STANDARD5_XLARGE2">STANDARD5_XLARGE2</a></code> | *No description.* |
 | <code><a href="#@cdklabs/cdk-ethereum-node.InstanceType.STANDARD5_XLARGE4">STANDARD5_XLARGE4</a></code> | *No description.* |
-| <code><a href="#@cdklabs/cdk-ethereum-node.InstanceType.COMPUTE5_LARGE">COMPUTE5_LARGE</a></code> | *No description.* |
 | <code><a href="#@cdklabs/cdk-ethereum-node.InstanceType.COMPUTE5_XLARGE">COMPUTE5_XLARGE</a></code> | *No description.* |
 | <code><a href="#@cdklabs/cdk-ethereum-node.InstanceType.COMPUTE5_XLARGE2">COMPUTE5_XLARGE2</a></code> | *No description.* |
 | <code><a href="#@cdklabs/cdk-ethereum-node.InstanceType.COMPUTE5_XLARGE4">COMPUTE5_XLARGE4</a></code> | *No description.* |
 
 ---
-
-##### `BURSTABLE3_MEDIUM` <a name="BURSTABLE3_MEDIUM" id="@cdklabs/cdk-ethereum-node.InstanceType.BURSTABLE3_MEDIUM"></a>
-
----
-
 
 ##### `BURSTABLE3_LARGE` <a name="BURSTABLE3_LARGE" id="@cdklabs/cdk-ethereum-node.InstanceType.BURSTABLE3_LARGE"></a>
 
@@ -273,11 +266,6 @@ Supported instance types for Managed Blockchain nodes.
 
 
 ##### `STANDARD5_XLARGE4` <a name="STANDARD5_XLARGE4" id="@cdklabs/cdk-ethereum-node.InstanceType.STANDARD5_XLARGE4"></a>
-
----
-
-
-##### `COMPUTE5_LARGE` <a name="COMPUTE5_LARGE" id="@cdklabs/cdk-ethereum-node.InstanceType.COMPUTE5_LARGE"></a>
 
 ---
 

--- a/src/node.ts
+++ b/src/node.ts
@@ -11,14 +11,12 @@ import * as utilities from './utilities';
  * Supported instance types for Managed Blockchain nodes
  */
 export enum InstanceType {
-  BURSTABLE3_MEDIUM = 'bc.t3.medium',
   BURSTABLE3_LARGE = 'bc.t3.large',
   BURSTABLE3_XLARGE = 'bc.t3.xlarge',
   STANDARD5_LARGE = 'bc.m5.large',
   STANDARD5_XLARGE = 'bc.m5.xlarge',
   STANDARD5_XLARGE2 = 'bc.m5.2xlarge',
   STANDARD5_XLARGE4 = 'bc.m5.4xlarge',
-  COMPUTE5_LARGE = 'bc.c5.large',
   COMPUTE5_XLARGE = 'bc.c5.xlarge',
   COMPUTE5_XLARGE2 = 'bc.c5.2xlarge',
   COMPUTE5_XLARGE4 = 'bc.c5.4xlarge',


### PR DESCRIPTION
The Amazon Managed Blockchain team is planning to update the documentation surrounding the instance types available for Ethereum nodes on Amazon Managed Blockchain. Updating to reflect the current list on the AWS Management Console. 