### PR TITLE
remove deprecated instance types

### DIFF
--- a/src/node.ts
+++ b/src/node.ts
@@ -11,13 +11,10 @@ import * as utilities from './utilities';
  * Supported instance types for Managed Blockchain nodes
  */
 export enum InstanceType {
-  BURSTABLE3_LARGE = 'bc.t3.large',
   BURSTABLE3_XLARGE = 'bc.t3.xlarge',
-  STANDARD5_LARGE = 'bc.m5.large',
   STANDARD5_XLARGE = 'bc.m5.xlarge',
   STANDARD5_XLARGE2 = 'bc.m5.2xlarge',
   STANDARD5_XLARGE4 = 'bc.m5.4xlarge',
-  COMPUTE5_XLARGE = 'bc.c5.xlarge',
   COMPUTE5_XLARGE2 = 'bc.c5.2xlarge',
   COMPUTE5_XLARGE4 = 'bc.c5.4xlarge',
 }

--- a/src/node.ts
+++ b/src/node.ts
@@ -97,7 +97,7 @@ export class EthereumNode extends constructs.Construct {
     // If no node configurations are provided, create one; the empty object
     // will be populated with defaults when passed to the node constructor
     this.network = props.network ?? Network.MAINNET;
-    this.instanceType = props.instanceType ?? InstanceType.BURSTABLE3_LARGE;
+    this.instanceType = props.instanceType ?? InstanceType.BURSTABLE3_XLARGE;
     this.region = region;
 
     // If no availability zone is provided, use the first in the region.

--- a/test/node.test.ts
+++ b/test/node.test.ts
@@ -20,13 +20,13 @@ describe('EthereumNode', () => {
       Properties: {
         NodeConfiguration: {
           AvailabilityZone: 'us-east-1a',
-          InstanceType: 'bc.t3.large',
+          InstanceType: 'bc.t3.xlarge',
         },
       },
     });
     expect(node.network).toBe(ethereum.Network.MAINNET);
     expect(node.availabilityZone).toBe('us-east-1a');
-    expect(node.instanceType).toBe(ethereum.InstanceType.BURSTABLE3_LARGE);
+    expect(node.instanceType).toBe(ethereum.InstanceType.BURSTABLE3_XLARGE);
   });
 
   test('Create an Ethereum node with a custom configuration', () => {


### PR DESCRIPTION
Fixes #309
Amazon Managed Blockchain instances of bc.t3.large, bc.m5.large, and bc.c5.xlarge are no longer supported with the new Ethereum Foundation hardware requirements